### PR TITLE
Use modern account name for release URL

### DIFF
--- a/source/Dockerfile
+++ b/source/Dockerfile
@@ -13,7 +13,7 @@ ARG TERRARIA_USER_NAME=terraria
 COPY default_config.json world/
 COPY start.sh /usr/local/bin/ 
 
-ADD https://github.com/NyxStudios/TShock/releases/download/v$TSHOCK_VERSION/tshock_$TSHOCK_VERSION.zip /
+ADD https://github.com/Pryaxis/TShock/releases/download/v$TSHOCK_VERSION/tshock_$TSHOCK_VERSION.zip /
 
 # jq --> for finding/replacing json value easily
 # moreutils --> to leverage sponge, which makes outputing a file from the jq step easier


### PR DESCRIPTION
* Not sure how I managed to use the old account/org before: https://github.com/NyxStudios/